### PR TITLE
Multiple discord servers

### DIFF
--- a/VerificationWeb/Configuration/Config.cs
+++ b/VerificationWeb/Configuration/Config.cs
@@ -20,10 +20,14 @@ namespace VerificationWeb.Configuration
         public string Subreddit { get; set; }
         public string RedhatSubreddit { get; set; }
         public string RedirectUri { get; set; }
+        
+        public List<ulong> ContributorRoles { get; set; }
+        public List<ulong> DotnetRoles { get; set; }
+        public List<ulong> RedhatRoles { get; set; }
         public Dictionary<string, ulong> DiscordRoles { get; set; }
         public Dictionary<string, string> RoleConditions { get; set; }
         public Dictionary<string, string> RedditFlairs { get; set; }
-        
+                
         public string RedhatOidcDiscoveryUri { get; set; }
     }
 }

--- a/VerificationWeb/Controllers/RoleController.cs
+++ b/VerificationWeb/Controllers/RoleController.cs
@@ -41,29 +41,16 @@ namespace VerificationWeb.Controllers
 
                 if (loginType == SessionClaims.FedoraScheme)
                 {
-                    string[] groups = HttpContext.Session.GetString(SessionClaims.Groups).Trim().Split();
+                    string groups = HttpContext.Session.GetString(SessionClaims.Groups);
 
-                    var availableRoles = new List<string>();
-
-                    string role;
-                    foreach (var group in groups)
-                    {
-                        if (_roleService.Config.RoleConditions.TryGetValue(group, out role))
-                        {
-                            availableRoles.Add(role);
-                        }
-                    }
-
-                    await _roleService.AssignRoleAsync(Convert.ToUInt64(userId), availableRoles);
-                    ViewData.Add("AddedRoles", availableRoles);
+                    var rolesNames = await _roleService.AssignRoleAsync(Convert.ToUInt64(userId), groups);
+                    ViewData.Add("AddedRoles", rolesNames);
                     return View("Discord");
                 }
 
                 if (loginType == SessionClaims.RedhatScheme)
                 {
-                    var rolesName = new List<string>();
-                    rolesName.Add(_roleService.Config.RoleConditions["Redhat"]);
-                    await _roleService.AssignRoleAsync(Convert.ToUInt64(userId), rolesName);
+                    var rolesName = await _roleService.AssignRoleAsync(Convert.ToUInt64(userId), "Redhat");
                     ViewData.Add("AddedRoles", rolesName);
                     return View("Discord");
                 }

--- a/VerificationWeb/Services/RoleService.cs
+++ b/VerificationWeb/Services/RoleService.cs
@@ -10,25 +10,65 @@ namespace VerificationWeb.Services
 {
     public class RoleService
     {
-        private readonly SocketGuild _guild;
+        private readonly DiscordSocketClient _client;
         public readonly Config Config;
 
         public RoleService(Config config, DiscordSocketClient client)
         {
             Config = config;
-            _guild = client.Guilds.FirstOrDefault(x => x.Id == Config.GuildId);
+            _client = client;
         }
 
-        public async Task AssignRoleAsync(ulong userId, IEnumerable<string> roleNames)
+        // Returns name of the roles
+        public async Task<List<string>> AssignRoleAsync(ulong userId, string groups)
         {
+            var roleNames = new List<string>();
             var rolesToAdd = new List<IRole>();
-                foreach (string roleName in roleNames)
+
+            foreach (var guild in _client.Guilds)
+            {
+                
+                if (!guild.Users.Any(x => x.Id == userId))
+                    break;
+
+                foreach (var role in guild.Roles)
                 {
-                    var roleId = Config.DiscordRoles[roleName];
-                    rolesToAdd.Add(_guild.GetRole(roleId));
+                    if (groups.Contains("cla/done"))
+                    {
+                        if (Config.ContributorRoles.Contains(role.Id))
+                        {
+                            var newRole = guild.GetRole(role.Id);
+                            rolesToAdd.Add(newRole);
+                            roleNames.Add(newRole.Name);
+                        }
+                    }
+
+                    if (groups.Contains("dotnet-team"))
+                    {
+                        if (Config.DotnetRoles.Contains(role.Id))
+                        {
+                            var newRole = guild.GetRole(role.Id);
+                            rolesToAdd.Add(newRole);
+                            roleNames.Add(newRole.Name);
+                        }
+                    }
+
+                    if (groups.Contains("Redhat"))
+                    {
+                        if (Config.RedhatRoles.Contains(role.Id))
+                        {
+                            var newRole = guild.GetRole(role.Id);
+                            rolesToAdd.Add(newRole);
+                            roleNames.Add(newRole.Name);
+                        }
+                    }
                 }
 
-            await _guild.GetUser(userId).AddRolesAsync(rolesToAdd);
+                await guild.GetUser(userId).AddRolesAsync(rolesToAdd);
+                rolesToAdd.Clear();
+            }
+
+            return roleNames;
         }
     }
 }

--- a/VerificationWeb/readme.md
+++ b/VerificationWeb/readme.md
@@ -30,11 +30,11 @@ Example config - appsettings.json
      "Redhat": "Redhat"                       <-- Key redhat is necessary, its value is the name of the discord role
   },
 
-  "DiscordRoles": {                             <-- Discord id of each role defined above
-    "Contributor" : 605756010153639956,
-    "Dotnet": 606110843276361729,
-    "Redhat": 649672841087942676                <-- "Redhat" key must be set (it can have different name based on the "Redhat" key value in RoleConditions), condition is automatically login through Redhat SSO
-  },
+  "ContributorRoles": [605756010153639956, 675171600278093834], <-- All roles that user gets as contributor
+  "DotnetRoles": [606110843276361729],
+  "RedhatRoles": [649672841087942676],
+    
+    
   "RedditFlairs" : {                            <-- Flair key = necessary groups, key name of the flair
     "cla/done" : "Contributor",
     "dotnet-team": "Dotnet",


### PR DESCRIPTION
Added option to use multiple guilds, so user gets all roles he can on any servers he is on.
So the config now has 3 arrays of roles ids, user will then get every role he can
"ContributorRoles": []
"DotnetRoles":  []
"RedhatRoles": []