### PR TITLE
Download user if not found in the cache

### DIFF
--- a/VerificationWeb/Services/RoleService.cs
+++ b/VerificationWeb/Services/RoleService.cs
@@ -31,10 +31,10 @@ namespace VerificationWeb.Services
             
             // Maybe TODO, prepend name of the guild to the role name so the user can see where he got the roles?
             
-            foreach (var guild in _client.Guilds)
+            foreach (IGuild guild in _client.Guilds)
             {
-                
-                if (guild.GetUser(userId) == null)
+                var user = await guild.GetUserAsync(userId); 
+                if (user == null)
                     continue;
 
                 if (isRedhat)
@@ -82,7 +82,7 @@ namespace VerificationWeb.Services
                     }
                 }
                 
-                await guild.GetUser(userId).AddRolesAsync(rolesToAdd);
+                await user.AddRolesAsync(rolesToAdd);
                 rolesToAdd.Clear();
             }
 

--- a/VerificationWeb/Services/RoleService.cs
+++ b/VerificationWeb/Services/RoleService.cs
@@ -29,8 +29,6 @@ namespace VerificationWeb.Services
             bool isContributor = groups.Contains("cla/done");
             bool isDotnet = groups.Contains("dotnet-team");
 
-            // Maybe TODO, prepend name of the guild to the role name so the user can see where he got the roles?
-
             foreach (var guild in _client.Guilds)
             {
                 IGuildUser user = guild.GetUser(userId);

--- a/VerificationWeb/Services/RoleService.cs
+++ b/VerificationWeb/Services/RoleService.cs
@@ -28,14 +28,18 @@ namespace VerificationWeb.Services
             bool isRedhat = groups.Contains("Redhat");
             bool isContributor = groups.Contains("cla/done");
             bool isDotnet = groups.Contains("dotnet-team");
-            
+
             // Maybe TODO, prepend name of the guild to the role name so the user can see where he got the roles?
-            
-            foreach (IGuild guild in _client.Guilds)
+
+            foreach (var guild in _client.Guilds)
             {
-                var user = await guild.GetUserAsync(userId); 
-                if (user == null)
-                    continue;
+                IGuildUser user = guild.GetUser(userId);
+                if (user == null) {
+                    user = await _client.Rest.GetGuildUserAsync(guild.Id, userId);
+                    if (user == null) {
+                        continue;
+                    }
+                }
 
                 if (isRedhat)
                 {
@@ -81,7 +85,7 @@ namespace VerificationWeb.Services
                         }
                     }
                 }
-                
+
                 await user.AddRolesAsync(rolesToAdd);
                 rolesToAdd.Clear();
             }


### PR DESCRIPTION
By switching to IGuild.GetUserAsync the user is looked up in the cache and if he is not found there, the function tries to download up-to date information and check there. Which would hopefully solve our unfound users in #32 